### PR TITLE
Fix backend tests by using Testcontainers MariaDB

### DIFF
--- a/backend/src/test/java/com/porkolab/chinesezodiac/ChinesezodiacApplicationTests.java
+++ b/backend/src/test/java/com/porkolab/chinesezodiac/ChinesezodiacApplicationTests.java
@@ -1,16 +1,37 @@
 package com.porkolab.chinesezodiac;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
-		classes = ChinesezodiacApplication.class,
-		properties = {
-			"spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
-		})
+        classes = ChinesezodiacApplication.class,
+        properties = {
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
+        })
 @ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class ChinesezodiacApplicationTests {
+
+        @Container
+        static MariaDBContainer<?> mariaDB = new MariaDBContainer<>("mariadb:10.11")
+                        .withDatabaseName("astropa_test")
+                        .withUsername("test")
+                        .withPassword("testpass");
+
+        @DynamicPropertySource
+        static void overrideDataSourceProperties(DynamicPropertyRegistry registry) {
+                registry.add("spring.datasource.url", mariaDB::getJdbcUrl);
+                registry.add("spring.datasource.username", mariaDB::getUsername);
+                registry.add("spring.datasource.password", mariaDB::getPassword);
+        }
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
## Summary
- run backend tests against a MariaDB Testcontainer
- fix Testcontainers import for MariaDB

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7183cf5c483329e561ac9992bdbfb